### PR TITLE
chore: mark maestro-ui package-lock as generated text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+maestro-ui/package-lock.json text linguist-generated=true

--- a/maestro-ui/package-lock.json
+++ b/maestro-ui/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "maestro-ui",
+  "lockfileVersion": 3,
+  "packages": {}
+}


### PR DESCRIPTION
## Summary
- mark `maestro-ui/package-lock.json` as text and linguist-generated via `.gitattributes`
- add a minimal `maestro-ui/package-lock.json` stub

## Testing
- `pytest tests/unittests` *(fails: 173 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6a696bec8333808d2be8d467d3bf